### PR TITLE
Replace landing background image with CSS gradients

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,11 +4,37 @@
 
 :root {
   color-scheme: light dark;
+  --aurora-light: radial-gradient(circle at 20% 20%, rgba(129, 140, 248, 0.3), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(34, 211, 238, 0.25), transparent 55%),
+    radial-gradient(circle at 10% 80%, rgba(251, 191, 36, 0.2), transparent 45%),
+    radial-gradient(circle at 90% 70%, rgba(196, 181, 253, 0.25), transparent 50%);
+  --aurora-dark: radial-gradient(circle at 20% 20%, rgba(76, 29, 149, 0.35), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(8, 145, 178, 0.25), transparent 55%),
+    radial-gradient(circle at 10% 80%, rgba(180, 83, 9, 0.2), transparent 50%),
+    radial-gradient(circle at 85% 75%, rgba(37, 99, 235, 0.25), transparent 55%);
 }
 
 body {
-  @apply bg-gradient-to-br from-white via-white/90 to-indigo-100/60 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950/40;
-  background-image: var(--tw-gradient-stops), theme('backgroundImage.aurora');
+  @apply relative min-h-screen overflow-x-hidden bg-gradient-to-br from-white via-white/90 to-indigo-100/60 text-slate-900 antialiased dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950/40 dark:text-slate-100;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: -35%;
+  z-index: -1;
+  background-image: var(--aurora-light);
+  background-repeat: no-repeat;
+  background-size: 140% 140%;
+  filter: blur(140px);
+  opacity: 0.85;
+  transform: translateZ(0);
+  pointer-events: none;
+}
+
+.dark body::before {
+  background-image: var(--aurora-dark);
+  opacity: 0.7;
 }
 
 .glass-card {


### PR DESCRIPTION
## Summary
- define light and dark aurora gradient presets in CSS and apply them via the body pseudo-element
- render the landing page background with blurred CSS gradients instead of an imported image while keeping existing glassmorphism styling

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dae11f8dc8832f96a3f45be9d17036