### PR TITLE
Update LinkCard redirect path

### DIFF
--- a/frontend/src/components/LinkCard.jsx
+++ b/frontend/src/components/LinkCard.jsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 export default function LinkCard({ link }) {
   return (
     <motion.a
-      href={`/go/${link.slug}`}
+      href={`/api/go/${link.slug}`}
       target="_self"
       rel="noopener noreferrer"
       className="glass-card flex items-center justify-between gap-4"


### PR DESCRIPTION
## Summary
- update the public LinkCard component so that it requests the backend redirect endpoint at /api/go/:slug

## Testing
- Manual verification: launched backend and frontend, clicked a link on the landing, and confirmed the browser navigated to the external URL while the backend logged the redirect

------
https://chatgpt.com/codex/tasks/task_e_68dae45b01b4832fb3d443ea85cc0824