### PR TITLE
Add configuration flag for secure session cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ ADMIN_PASS=admin123
 SESSION_SECRET=supersecret
 HASH_SALT=supersecret
 PORT=3000
+SESSION_COOKIE_SECURE=false # Set to true only when serving over HTTPS

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -15,5 +15,7 @@ export const config = {
   adminPass: process.env.ADMIN_PASS || 'admin123',
   sessionSecret: process.env.SESSION_SECRET || 'supersecret',
   env: process.env.NODE_ENV || 'development',
-  hashSalt: process.env.HASH_SALT || process.env.SESSION_SECRET || 'supersecret'
+  hashSalt: process.env.HASH_SALT || process.env.SESSION_SECRET || 'supersecret',
+  sessionCookieSecure:
+    (process.env.SESSION_COOKIE_SECURE || 'false').toLowerCase() === 'true'
 };

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -47,8 +47,8 @@ app.use(
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: config.env === 'production',
-      sameSite: config.env === 'production' ? 'strict' : 'lax'
+      secure: config.sessionCookieSecure,
+      sameSite: config.sessionCookieSecure ? 'strict' : 'lax'
     }
   })
 );


### PR DESCRIPTION
## Summary
- add a SESSION_COOKIE_SECURE flag to the backend config so deployments can control cookie security
- document the new environment variable in the example env file for operators
- update the session middleware to respect the flag and default to lax sameSite when not secure

## Testing
- `npm --prefix backend run start`


------
https://chatgpt.com/codex/tasks/task_e_68daf85c81d8832f849fccce0ebee837